### PR TITLE
Changing default port setting to define 1 stop bit

### DIFF
--- a/src/xsens_mti_ros2_driver/lib/xspublic/xscontroller/iointerface.h
+++ b/src/xsens_mti_ros2_driver/lib/xspublic/xscontroller/iointerface.h
@@ -103,7 +103,7 @@ public:
 		PO_XonXoffFlowControl	= (1 << 2),
 		PO_OneStopBit		= 0,
 		PO_TwoStopBits		= (1 << 3),
-		PO_XsensDefaults	= (PO_NoFlowControl | PO_TwoStopBits)
+		PO_XsensDefaults	= (PO_NoFlowControl | PO_OneStopBit)
 	};
 	// SerialInterface overridable functions
 	virtual XsResultValue open(const XsPortInfo& portInfo, XsFilePos readBufSize = XS_DEFAULT_READ_BUFFER_SIZE, XsFilePos writeBufSize = XS_DEFAULT_WRITE_BUFFER_SIZE, PortOptions options = PO_XsensDefaults);


### PR DESCRIPTION
This PR proposes a minor change to the default port settings specified in `xspublic/xscontroller/iointerface.h`.  I have changed the default setting specified in this file to `PO_OneStopBit` instead of `PO_TwoStopBits`.

As mentioned in [this tutorial](https://base.movella.com/s/article/Interfacing-MTi-devices-with-the-Raspberry-Pi) for Raspberry Pi, most UART port uses 8N1 (1 stop bit), and Xsens has only some old devices that use 2 stop bits so it makes sense for the default behaviour to be 1 stop bit instead of 2 stop bits.

Without this change interfacing the MTi device via UART inevitably fails and results in "No Mti device found. Verify port and baudrate" error.

I have tested this change successfully with the IMU connected via both UART and USB interface to a board carrying a Jetson Orin NX using an MTi-1 device. 